### PR TITLE
Run tests in Travis CI, provide execution environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - make docker-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && apt-get install -y python3 python3-dev python3-pip 
 
+RUN python3 -m pip install --upgrade pip
 ADD requirements.txt requirements.txt
 RUN python3 -m pip install -r requirements.txt
-RUN mkdir -p /io
+RUN pwd
+# install fmmgen package here
+ADD . io
+RUN python3 -m pip install -e io
 WORKDIR /io
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && apt-get install -y python3 python3-dev python3-pip 
+
+ADD requirements.txt requirements.txt
+RUN python3 -m pip install -r requirements.txt
+RUN mkdir -p /io
+WORKDIR /io
+CMD ["/bin/bash"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Ryan Pepper, University of Southampton
+Copyright (c) 2019 Ryan Pepper, Hans Fangohr University of Southampton
 
 All rights reserved.
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,43 @@
-install:
-	pip3 install -e . --user
+all:
+	make install
+	make test
+	make ipython
 
-runtests:
+docker-all:
+	make docker-build
+	make docker-install
+	make docker-test
+	make docker-ipython
+	make docker-bash
+
+
+install:
+	python3 -m pip install .
+
+test:
 	cd tests && py.test -v
+
+ipython:
+	ipython
+
+# To use Docker container for building and testing
+# build docker image locally, needs to be done first
+
+docker-build:
+	docker build -t fmmgen -f Dockerfile .
+
+docker-install:
+	docker run -v `pwd`:/io fmmgen make install
+
+docker-test:
+	docker run -v `pwd`:/io fmmgen make test
+
+docker-ipython:
+	docker run -ti -v `pwd`:/io fmmgen ipython
+
+docker-bash:
+	docker run -ti -v `pwd`:/io fmmgen bash
+
 
 clean:
 	rm -rf tests/operators_decl.pxd

--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,11 @@ clean:
 	rm -rf *.egg-info
 	rm -rf __pycache__
 	rm -rf *~
+	rm -rf tests/LinearDipole.c
+	rm -rf tests/LinearDipole.h
+	rm -rf tests/LinearQuadrupole.c
+	rm -rf tests/LinearQuadrupole.h
+	rm -rf tests/MonopoleOrigin.c
+	rm -rf tests/MonopoleOrigin.h
+	rm -rf tests/QuadrupoleTwoDipoles.c
+	rm -rf tests/QuadrupoleTwoDipoles.h

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,14 @@ all:
 	make ipython
 
 docker-all:
+  # docker-build also installs software in container
 	make docker-build
-	make docker-install
 	make docker-test
-	make docker-ipython
-	make docker-bash
+	@echo "Build, install and tests run. Looking good."
 
 
 install:
-	python3 -m pip install .
+	python3 -m pip install -e .
 
 test:
 	cd tests && py.test -v
@@ -26,17 +25,16 @@ ipython:
 docker-build:
 	docker build -t fmmgen -f Dockerfile .
 
-docker-install:
-	docker run -v `pwd`:/io fmmgen make install
-
 docker-test:
-	docker run -v `pwd`:/io fmmgen make test
+	docker run --rm -v `pwd`:/io fmmgen make test
 
+# for interactive exploration
 docker-ipython:
-	docker run -ti -v `pwd`:/io fmmgen ipython
+	docker run --rm -ti -v `pwd`:/io fmmgen ipython
 
+# for diagnostic purposes and convenience
 docker-bash:
-	docker run -ti -v `pwd`:/io fmmgen bash
+	docker run --rm -ti -v `pwd`:/io fmmgen bash
 
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # fmmgen
 ![Python version](https://img.shields.io/badge/Python-%3E%3D%203.6-brightgreen.svg)
 
-This package generates Fast Multipole and Barnes-Hut operators for use in tree codes.
-It was written as part of the PhD research of Ryan Alexander Pepper at the University of Southampton.
+This package generates Fast Multipole and Barnes-Hut operators for use in tree codes using automatic code generation.
 
-The library is written in Python, and version 3.6. The package has few dependencies; the main one is the SymPy library. Some parts of the SymPy library are bundled within fmmgen due to changes needing to be made to the underlying methods for the purposes of this code. Accordingly, fmmgen is licensed under the 3-Clause BSD License.
+It was written as part of the PhD research of Ryan Alexander Pepper at the
+University of Southampton, under supervision of Hans Fangohr.
+
+The library is written in Python (version 3.6). The package has few
+dependencies; the main one is the SymPy library. Some parts of the SymPy library
+are bundled within fmmgen due to changes needing to be made to the underlying
+methods for the purposes of this code. Accordingly, fmmgen is licensed under the
+3-Clause BSD License.
 
 fmmgen consists of several parts:
 
@@ -58,6 +64,12 @@ import operators_wrap as fmm
 
 Alternatively, we suggest looking in the 'example' folder for a fully functioning OpenMP parallelised implementation of the FMM and Barnes-Hut methods using the code generated operators, which works for Coulomb, Dipole and higher order sources; all that needs to be done is change the 'source_order' parameter. By making other changes in the example.py file, one can enable or disable optimisations, which affects the run time significantly for some compilers. In general, we do not recommend the use of the GNU compiler, as in testing we find that the performance of the methods are significantly worse than when compiled with the Intel compiler. This has a side effect; we find that the symbolic algebra optimisations have less of an effect on the performance with the Intel compiler, which can factor expressions more effectively to avoid repeated computations than the GNU compiler at high optimisation levels.
 
+## How to cite
+
+A paper describing the work is under preparation. For now, please cite as
+
+RA Pepper and H Fangohr, fmmgen, http://github.com/rpep/fmmgen (2019)
+
 ## References
 
 The code was developed with particular reference to the following academic papers.
@@ -69,5 +81,10 @@ The code was developed with particular reference to the following academic paper
 [3] Beatson, R. and Greengard, L. (1997) A short course on fast multipole methods. In "Wavelets, Multilevel Methods and Elliptic PDEs", Oxford University Press, ISBN 0 19 850190 0
 
 In addition, I would also point anyone interested in the Fast Multipole Method to the [video tutorial series](https://www.youtube.com/playlist?list=PLpa6_YduENMF080NikNninGG-7e1hK1eQ) of Dr. Rio Yokota of the Tokyo Institute of Technology for an overview and short course developing the 2-D method in a step-by-step way.
+
+## Acknowledgements
+
+This work was supported by the EPSRC Centre for Doctoral Training in Next
+Generation Computational Modelling (grant EP/L015382/1).
 
 I would also like to thank J. P. Coles for useful discussions regarding the method and implementation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-Cython>=0.28.3
-numpy>=1.14.3
-sympy>=1.3
+cython
+numpy
+sympy
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cython
 numpy
 sympy
 pytest
+ipython


### PR DESCRIPTION
This PR allows to
- build the software in a docker container
- executes the tests in the docker container
- allows travis to carry out the whole process as part of  continuous integration

Should be useful to 
- monitor if the tests carry on passing as libraries this depends on may update (Travis should run tests regularly, maybe once per month)
- potential users to quickly install the software (in a docker container on their own machine)
- run the tests and software in well defined environment, if user only has Windows or OS X or a particular Linux flavour available.

Things that need doing after merging this:
- link Travis CI to this repo
- fix the tests that currently fails